### PR TITLE
[FIX/REMOVAL] Remove o skill de self-surgery temporariamente para que a nanomed funcione.

### DIFF
--- a/code/modules/vending/medical.dm
+++ b/code/modules/vending/medical.dm
@@ -32,7 +32,7 @@
 					/obj/item/stackremover = 5,
 					//SKYRAT EDIT END
 					//NEBULA CHANGE BEGIN
-					/obj/item/skillchip/job/medical = 4
+					///obj/item/skillchip/job/medical = 4
 					//NEBULA CHANGE END
 					)
 	refill_canister = /obj/item/vending_refill/medical


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Eu GENUINAMENTE, DE CORAÇÃO, NÃO SEI, O QUE TÁ ACONTECENDO COM A NANOMED, isso é tipo o coconut do tf2, o path do skillchip tá correto, a amount é uma int, e a lista tá separada por vírgulas, mas mesmo assim, ter ele torna a nanomed inusável, o que é incrível pois TAVA FUNCIONANDO NO REPO ANTIGO.

Não sei se isso vai corrigir, mas no meu server privado de testes, isso arrumou, se não voltar a funcionar eu duvido que o que está acontecendo com a máquina está sob meu controle.

## How This Contributes To The Skyrat Roleplay Experience

Jogar med sem nanomed é foda

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
del: Removed self surgery skillchip from nanomed temporarily
/:cl:
